### PR TITLE
Expose FBExceptions header

### DIFF
--- a/WebDriverAgentLib/WebDriverAgentLib.h
+++ b/WebDriverAgentLib/WebDriverAgentLib.h
@@ -30,6 +30,7 @@ FOUNDATION_EXPORT const unsigned char WebDriverAgentLib_VersionString[];
 #import <WebDriverAgentLib/FBElementCommands.h>
 #import <WebDriverAgentLib/FBElementTypeTransformer.h>
 #import <WebDriverAgentLib/FBErrorBuilder.h>
+#import <WebDriverAgentLib/FBExceptions.h>
 #import <WebDriverAgentLib/FBExceptionHandler.h>
 #import <WebDriverAgentLib/FBFindElementCommands.h>
 #import <WebDriverAgentLib/FBHTTPStatusCodes.h>

--- a/WebDriverAgentLib/include/WebDriverAgentLib/FBExceptions.h
+++ b/WebDriverAgentLib/include/WebDriverAgentLib/FBExceptions.h
@@ -1,0 +1,1 @@
+../../Routing/FBExceptions.h


### PR DESCRIPTION
# Description

Expose [`FBExceptions` header](https://github.com/appium/WebDriverAgent/blob/8cef7bcc75a56e74d81e06d6791cc93b3c4b5461/WebDriverAgentLib/Routing/FBExceptions.m#L10).