### PR TITLE
Implement QAWSnapshot utility class

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -65,6 +65,7 @@ let package = Package(
                 .headerSearchPath("Categories"),
                 .headerSearchPath("Commands"),
                 .headerSearchPath("include/WebDriverAgentLib"),
+                .headerSearchPath("QAWolf"),
                 .headerSearchPath("../PrivateHeaders/XCTest"),
                 .headerSearchPath("../PrivateHeaders/MobileCoreServices"),
                 .headerSearchPath("../PrivateHeaders/AccessibilityUtilities"),

--- a/WebDriverAgentLib/QAWolf/ExecuteWDACommand.h
+++ b/WebDriverAgentLib/QAWolf/ExecuteWDACommand.h
@@ -5,7 +5,6 @@
 //  Created by Elton Carreiro on 28/08/25.
 //
 
-// ExceptionCatcher.h
 #import <Foundation/Foundation.h>
 #import <WebDriverAgentLib/FBCommandStatus.h>
 #import <WebDriverAgentLib/FBResponseJSONPayload.h>

--- a/WebDriverAgentLib/QAWolf/ExecuteWDACommand.m
+++ b/WebDriverAgentLib/QAWolf/ExecuteWDACommand.m
@@ -5,7 +5,6 @@
 //  Created by Elton Carreiro on 28/08/25.
 //
 
-// ExceptionCatcher.m
 #import "ExecuteWDACommand.h"
 #import "HandleWDACommandException.h"
 #import <WebDriverAgentLib/FBResponseJSONPayload.h>

--- a/WebDriverAgentLib/QAWolf/QAWSnapshotResult.h
+++ b/WebDriverAgentLib/QAWolf/QAWSnapshotResult.h
@@ -1,0 +1,17 @@
+//
+//  QAWSnapshotResult.h
+//  WebDriverAgent
+//
+//  Created by E. P. CARREIRO - SERVICOS DE INFORMATICA on 09/09/25.
+//
+
+#import <XCTest/XCTest.h>
+
+@interface QAWSnapshotResult : NSObject
+@property (nonatomic, strong, nullable) id<XCUIElementSnapshot> snapshot;
+@property (nonatomic, strong, nullable) NSException *exception;
+@property (nonatomic, readonly) BOOL isSuccess;
+
++ (instancetype)resultWithSnapshot:(id<XCUIElementSnapshot> _Nonnull)snapshot;
++ (instancetype _Nonnull )resultWithException:(NSException * _Nonnull)exception;
+@end

--- a/WebDriverAgentLib/QAWolf/QAWSnapshotResult.m
+++ b/WebDriverAgentLib/QAWolf/QAWSnapshotResult.m
@@ -1,0 +1,43 @@
+//
+//  QAWSnapshotResult.m.m
+//  WebDriverAgent
+//
+//  Created by E. P. CARREIRO - SERVICOS DE INFORMATICA on 09/09/25.
+//
+
+#import "QAWSnapshotResult.h"
+#import <XCTest/XCTest.h>
+
+@implementation QAWSnapshotResult
+
+- (BOOL)isSuccess {
+    return self.snapshot != nil && self.exception == nil;
+}
+
+- (instancetype)initWithSnapshot:(id<XCUIElementSnapshot> _Nonnull)snapshot {
+    self = [super init];
+    if (self) {
+        _snapshot = snapshot;
+        _exception = nil;
+    }
+    return self;
+}
+
+- (instancetype)initWithException:(NSException *)exception {
+    self = [super init];
+    if (self) {
+        _snapshot = nil;
+        _exception = exception;
+    }
+    return self;
+}
+
++ (instancetype)resultWithSnapshot:(id<XCUIElementSnapshot> _Nonnull)snapshot {
+    return [[self alloc] initWithSnapshot:snapshot];
+}
+
++ (instancetype)resultWithException:(NSException *)exception {
+    return [[self alloc] initWithException:exception];
+}
+
+@end

--- a/WebDriverAgentLib/QAWolf/XCUIElement+QAWSnapshotUtilities.h
+++ b/WebDriverAgentLib/QAWolf/XCUIElement+QAWSnapshotUtilities.h
@@ -1,0 +1,8 @@
+#import "XCUIElement+FBUtilities.h"
+#import "QAWSnapshotResult.h"
+
+@interface XCUIElement (QAWSnapshotUtilities)
+
+- (QAWSnapshotResult * _Nonnull)qaw_nativeSnapshotWithMaxDepth:(NSNumber *) maxDepth;
+
+@end

--- a/WebDriverAgentLib/QAWolf/XCUIElement+QAWSnapshotUtilities.m
+++ b/WebDriverAgentLib/QAWolf/XCUIElement+QAWSnapshotUtilities.m
@@ -1,0 +1,30 @@
+#import "FBConfiguration.h"
+#import "XCUIElement+FBUtilities.h"
+#import "QAWSnapshotResult.h"
+
+@implementation XCUIElement (QAWSnapshotUtilities)
+
+- (QAWSnapshotResult * _Nonnull)qaw_nativeSnapshotWithMaxDepth:(NSNumber *)maxDepth {
+    NSNumber *originalMaxDepth = @(FBConfiguration.snapshotMaxDepth);
+    [FBConfiguration setSnapshotMaxDepth:[maxDepth intValue]];
+
+    id<XCUIElementSnapshot> snapshot = nil;
+    NSException *caughtException = nil;
+
+    @try {
+        snapshot = (id<XCUIElementSnapshot>)[self fb_standardSnapshot];
+    }
+    @catch (NSException *exception) {
+        caughtException = exception;
+    }
+
+    [FBConfiguration setSnapshotMaxDepth:[originalMaxDepth intValue]];
+
+    if (caughtException) {
+        return [QAWSnapshotResult resultWithException:caughtException];
+    } else {
+        return [QAWSnapshotResult resultWithSnapshot:snapshot];
+    }
+}
+
+@end

--- a/WebDriverAgentLib/WebDriverAgentLib.h
+++ b/WebDriverAgentLib/WebDriverAgentLib.h
@@ -84,3 +84,5 @@ FOUNDATION_EXPORT const unsigned char WebDriverAgentLib_VersionString[];
 // QAWolf code
 #import <WebDriverAgentLib/ExecuteWDACommand.h>
 #import <WebDriverAgentLib/HandleWDACommandException.h>
+#import <WebDriverAgentLib/XCUIElement+QAWSnapshotUtilities.h>
+#import <WebDriverAgentLib/QAWSnapshotResult.h>

--- a/WebDriverAgentLib/include/WebDriverAgentLib/QAWSnapshotResult.h
+++ b/WebDriverAgentLib/include/WebDriverAgentLib/QAWSnapshotResult.h
@@ -1,0 +1,1 @@
+../../QAWolf/QAWSnapshotResult.h

--- a/WebDriverAgentLib/include/WebDriverAgentLib/XCUIElement+QAWSnapshotUtilities.h
+++ b/WebDriverAgentLib/include/WebDriverAgentLib/XCUIElement+QAWSnapshotUtilities.h
@@ -1,0 +1,1 @@
+../../QAWolf/XCUIElement+QAWSnapshotUtilities.h


### PR DESCRIPTION
# Description

- Extend `XCUIElement` by adding nwe `qaw_nativeSnapshotWithMaxDepth`;
- Add utility class `QAWSnapshotResult` which wraps either the snapshot or exception. We can't have unhandled Objective-C exceptions when calling it from Swift, so this class encapsulates the result for us.