### PR TITLE
Implement XML generation with arbitrary depth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
 ## Build generated
+.build/
 build/
 clang/
 DerivedData

--- a/Package.swift
+++ b/Package.swift
@@ -71,7 +71,6 @@ let package = Package(
                 .headerSearchPath("../PrivateHeaders/AccessibilityUtilities"),
                 .headerSearchPath("../PrivateHeaders/TextInput"),
                 .headerSearchPath("../PrivateHeaders/UIKitCore"),
-                .headerSearchPath("../PrivateHeaders/CoreGraphics"),
             ],
             linkerSettings: [
                 // Link against XCTest and system UIKit/Foundation frameworks that
@@ -80,8 +79,7 @@ let package = Package(
                 .linkedFramework("UIKit"),
                 .linkedFramework("Foundation"),
                 .linkedFramework("MobileCoreServices"),
-                .linkedFramework("UniformTypeIdentifiers"),
-                .linkedFramework("CoreGraphics"),
+                .linkedFramework("UniformTypeIdentifiers")
             ]
         ),
         // Unit-test target (optional – keeps parity with the original project).

--- a/Package.swift
+++ b/Package.swift
@@ -71,6 +71,7 @@ let package = Package(
                 .headerSearchPath("../PrivateHeaders/AccessibilityUtilities"),
                 .headerSearchPath("../PrivateHeaders/TextInput"),
                 .headerSearchPath("../PrivateHeaders/UIKitCore"),
+                .headerSearchPath("../PrivateHeaders/CoreGraphics"),
             ],
             linkerSettings: [
                 // Link against XCTest and system UIKit/Foundation frameworks that
@@ -79,7 +80,8 @@ let package = Package(
                 .linkedFramework("UIKit"),
                 .linkedFramework("Foundation"),
                 .linkedFramework("MobileCoreServices"),
-                .linkedFramework("UniformTypeIdentifiers")
+                .linkedFramework("UniformTypeIdentifiers"),
+                .linkedFramework("CoreGraphics"),
             ]
         ),
         // Unit-test target (optional – keeps parity with the original project).

--- a/WebDriverAgentLib/QAWolf/QAWXMLStringResult.h
+++ b/WebDriverAgentLib/QAWolf/QAWXMLStringResult.h
@@ -1,0 +1,17 @@
+//
+//  QAWSnapshotResult.h
+//  WebDriverAgent
+//
+//  Created by E. P. CARREIRO - SERVICOS DE INFORMATICA on 09/09/25.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface QAWXMLStringResult : NSObject
+@property (nonatomic, strong, nullable) NSString *xml;
+@property (nonatomic, strong, nullable) NSException *exception;
+@property (nonatomic, readonly) BOOL isSuccess;
+
++ (instancetype _Nonnull)resultWithXML:(NSString * _Nullable)xml;
++ (instancetype _Nonnull )resultWithException:(NSException * _Nonnull)exception;
+@end

--- a/WebDriverAgentLib/QAWolf/QAWXMLStringResult.m
+++ b/WebDriverAgentLib/QAWolf/QAWXMLStringResult.m
@@ -1,0 +1,43 @@
+//
+//  QAWSnapshotResult.m.m
+//  WebDriverAgent
+//
+//  Created by E. P. CARREIRO - SERVICOS DE INFORMATICA on 09/09/25.
+//
+
+#import "QAWXMLStringResult.h"
+#import <XCTest/XCTest.h>
+
+@implementation QAWXMLStringResult
+
+- (BOOL)isSuccess {
+    return self.xml != nil && self.exception == nil;
+}
+
+- (instancetype)initWithXML:(NSString * _Nullable)xml {
+    self = [super init];
+    if (self) {
+        _xml = xml;
+        _exception = nil;
+    }
+    return self;
+}
+
+- (instancetype)initWithException:(NSException *)exception {
+    self = [super init];
+    if (self) {
+        _xml = nil;
+        _exception = exception;
+    }
+    return self;
+}
+
++ (instancetype)resultWithXML:(NSString * _Nullable)xml {
+    return [[self alloc] initWithXML:xml];
+}
+
++ (instancetype)resultWithException:(NSException *)exception {
+    return [[self alloc] initWithException:exception];
+}
+
+@end

--- a/WebDriverAgentLib/QAWolf/QAWXMLStringResult.m
+++ b/WebDriverAgentLib/QAWolf/QAWXMLStringResult.m
@@ -8,6 +8,9 @@
 #import "QAWXMLStringResult.h"
 #import <XCTest/XCTest.h>
 
+/**
+    Swift can't catch Objective-C exceptions. This wrapper object holds a reference either of XML string or NSException, so Swift code can inspect possible errors.
+ */
 @implementation QAWXMLStringResult
 
 - (BOOL)isSuccess {

--- a/WebDriverAgentLib/QAWolf/XCUIElement+QAWXML.h
+++ b/WebDriverAgentLib/QAWolf/XCUIElement+QAWXML.h
@@ -1,0 +1,23 @@
+//
+//  XCUIELement+XML.h
+//  WebDriverAgent
+//
+//  Created by E. P. CARREIRO - SERVICOS DE INFORMATICA on 11/09/25.
+//
+
+#import <XCTest/XCTest.h>
+#import "QAWXMLStringResult.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class FBXMLGenerationOptions;
+
+@interface XCUIElement (QAWXML)
+
+- (QAWXMLStringResult * _Nonnull)qaw_xmlStringWithOptions:(FBXMLGenerationOptions * _Nullable)options
+                                   withMaxDepth:(NSNumber *)maxDepth;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/WebDriverAgentLib/QAWolf/XCUIElement+QAWXML.m
+++ b/WebDriverAgentLib/QAWolf/XCUIElement+QAWXML.m
@@ -14,6 +14,9 @@
 
 @implementation XCUIElement (QAWXML)
 
+/**
+    Takes an element snapshot based on passed max depth. This function changes and restores the max depth configuration injected by WDA.
+ */
 - (QAWXMLStringResult * _Nonnull)qaw_xmlStringWithOptions:(FBXMLGenerationOptions * _Nullable)options
                                       withMaxDepth:(NSNumber *)maxDepth
 {
@@ -24,6 +27,7 @@
     NSException *caughtException = nil;
 
     @try {
+        // We can cast XCUIElement to FBElement as WDA implements the protocol agreement
         id<FBElement> root = (id<FBElement>) self;
         xml = [FBXPath xmlStringWithRootElement:root options:options];
     }

--- a/WebDriverAgentLib/QAWolf/XCUIElement+QAWXML.m
+++ b/WebDriverAgentLib/QAWolf/XCUIElement+QAWXML.m
@@ -1,0 +1,44 @@
+//
+//  XCUIElement+QAWXML.m
+//  WebDriverAgent
+//
+//  Created by E. P. CARREIRO - SERVICOS DE INFORMATICA on 11/09/25.
+//
+
+#import "XCUIElement+QAWXML.h"
+#import "FBElement.h"
+#import "FBXPath.h"
+#import "FBXMLGenerationOptions.h"
+#import "FBConfiguration.h"
+#import "QAWXMLStringResult.h"
+
+@implementation XCUIElement (QAWXML)
+
+- (QAWXMLStringResult * _Nonnull)qaw_xmlStringWithOptions:(FBXMLGenerationOptions * _Nullable)options
+                                      withMaxDepth:(NSNumber *)maxDepth
+{
+    NSNumber *originalMaxDepth = @(FBConfiguration.snapshotMaxDepth);
+    [FBConfiguration setSnapshotMaxDepth:[maxDepth intValue]];
+
+    NSString * _Nonnull xml = @"";
+    NSException *caughtException = nil;
+
+    @try {
+        id<FBElement> root = (id<FBElement>) self;
+        xml = [FBXPath xmlStringWithRootElement:root options:options];
+    }
+    @catch (NSException *exception) {
+        caughtException = exception;
+    }
+
+    [FBConfiguration setSnapshotMaxDepth:[originalMaxDepth intValue]];
+
+    if (caughtException) {
+        return [QAWXMLStringResult resultWithException:caughtException];
+    } else {
+        return [QAWXMLStringResult resultWithXML:xml];
+    }
+    
+}
+
+@end

--- a/WebDriverAgentLib/WebDriverAgentLib.h
+++ b/WebDriverAgentLib/WebDriverAgentLib.h
@@ -58,6 +58,7 @@ FOUNDATION_EXPORT const unsigned char WebDriverAgentLib_VersionString[];
 #import <WebDriverAgentLib/FBXCElementSnapshot.h>
 #import <WebDriverAgentLib/FBXCElementSnapshotWrapper.h>
 #import <WebDriverAgentLib/FBXCodeCompatibility.h>
+#import <WebDriverAgentLib/FBXMLGenerationOptions.h>
 #import <WebDriverAgentLib/FBXPath.h>
 #import <WebDriverAgentLib/WebDriverAgentLib.h>
 #import <WebDriverAgentLib/XCDebugLogDelegate-Protocol.h>
@@ -86,3 +87,5 @@ FOUNDATION_EXPORT const unsigned char WebDriverAgentLib_VersionString[];
 #import <WebDriverAgentLib/HandleWDACommandException.h>
 #import <WebDriverAgentLib/XCUIElement+QAWSnapshotUtilities.h>
 #import <WebDriverAgentLib/QAWSnapshotResult.h>
+#import <WebDriverAgentLib/XCUIElement+QAWXML.h>
+#import <WebDriverAgentLib/QAWXMLStringResult.h>

--- a/WebDriverAgentLib/include/WebDriverAgentLib/FBXMLGenerationOptions.h
+++ b/WebDriverAgentLib/include/WebDriverAgentLib/FBXMLGenerationOptions.h
@@ -1,0 +1,1 @@
+../../Utilities/FBXMLGenerationOptions.h

--- a/WebDriverAgentLib/include/WebDriverAgentLib/QAWXMLStringResult.h
+++ b/WebDriverAgentLib/include/WebDriverAgentLib/QAWXMLStringResult.h
@@ -1,0 +1,1 @@
+../../QAWolf/QAWXMLStringResult.h

--- a/WebDriverAgentLib/include/WebDriverAgentLib/XCUIElement+QAWXML.h
+++ b/WebDriverAgentLib/include/WebDriverAgentLib/XCUIElement+QAWXML.h
@@ -1,0 +1,1 @@
+../../QAWolf/XCUIElement+QAWXML.h


### PR DESCRIPTION
# Description

We need to be able to specify the depth we want when generating the snapshot. This PR implements a function that injects the desired depth and uses the existing [xmlStringWithRootElement](https://github.com/appium/WebDriverAgent/blob/698a1ad882f5012b4e00d76723634798a03706e2/WebDriverAgentLib/Utilities/FBXPath.m#L156) function to generate the XML.