### PR TITLE
Export QAWObjCExceptionDomain constant

### DIFF
--- a/WebDriverAgentLib/QAWolf/QAWObjCExceptionHandler.h
+++ b/WebDriverAgentLib/QAWolf/QAWObjCExceptionHandler.h
@@ -9,6 +9,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/** Domain used for NSErrors produced by QAWObjCExceptionHandler. */
+extern NSString* const QAWObjCExceptionDomain;
+
 typedef id _Nullable (^ObjCExceptionBlock)(void);
 
 @interface QAWObjCExceptionHandler : NSObject

--- a/WebDriverAgentLib/QAWolf/QAWObjCExceptionHandler.m
+++ b/WebDriverAgentLib/QAWolf/QAWObjCExceptionHandler.m
@@ -6,6 +6,8 @@
 //
 #import "QAWObjCExceptionHandler.h"
 
+NSString* const QAWObjCExceptionDomain = @"QAWObjCExceptionDomain";
+
 @implementation QAWObjCExceptionHandler
 
 + (id _Nullable)tryBlock:(ObjCExceptionBlock)block
@@ -27,7 +29,7 @@
                 userInfo[@"callStackSymbols"] = exception.callStackSymbols;
             }
             
-            *error = [NSError errorWithDomain:@"QAWObjCExceptionDomain"
+            *error = [NSError errorWithDomain:QAWObjCExceptionDomain
                                          code:-1
                                      userInfo:userInfo];
         }


### PR DESCRIPTION
Closes part of GEN-1759.

## Why

The string `"QAWObjCExceptionDomain"` was duplicated between this fork (used as the
domain when wrapping a caught NSException into an NSError) and `qawolf/ios-agent`'s
`LaunchRetry.swift` (where it's matched on to detect FrontBoard-NotFound races and
retry `XCUIApplication.launch()`). If the string ever changed in one place, the matcher
would silently stop firing and we'd regress to the original symptom.

## What

- Declare `extern NSString* const QAWObjCExceptionDomain;` in
  `WebDriverAgentLib/QAWolf/QAWObjCExceptionHandler.h`.
- Define it in `QAWObjCExceptionHandler.m` and use the symbol in the existing
  `errorWithDomain:` call instead of the literal.

Pattern matches `WebDriverAgentLib/Utilities/FBCapabilities.h`/`.m`. The umbrella
header `WebDriverAgentLib.h` already imports `QAWObjCExceptionHandler.h`, so the new
constant is automatically visible to Swift consumers via `import WebDriverAgentLib` —
no additional wiring required.
