### PR TITLE
PoC: log fb_hasVisibleDescendants hit rate

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -8,7 +8,10 @@
 
 #import "XCUIElement+FBIsVisible.h"
 
+#import <stdatomic.h>
+
 #import "FBElementUtils.h"
+#import "FBLogger.h"
 #import "FBXCodeCompatibility.h"
 #import "FBXCElementSnapshotWrapper+Helpers.h"
 #import "XCUIElement+FBUtilities.h"
@@ -36,12 +39,40 @@ NSNumber* _Nullable fetchSnapshotVisibility(id<FBXCElementSnapshot> snapshot)
 
 - (BOOL)fb_hasVisibleDescendants
 {
+  // PoC (poc/log-tier-b-cache-hits): observability-only. Instrument the Tier B
+  // short-circuit so we can measure how often it actually fires vs falls
+  // through to the Tier C synchronous AX-framework IPC. Counters are
+  // process-wide and accumulate across requests; logging every 50 calls keeps
+  // the output volume tractable on dense screens (500+ nodes per /source).
+  // No behaviour change — this PR only adds the log line.
+  static _Atomic NSUInteger fbVisCacheTierBCalls = 0;
+  static _Atomic NSUInteger fbVisCacheTierBHits = 0;
+
+  NSUInteger descendantsWalked = 0;
+  BOOL hit = NO;
   for (id<FBXCElementSnapshot> descendant in (self._allDescendants ?: @[])) {
+    descendantsWalked++;
     if ([fetchSnapshotVisibility(descendant) boolValue]) {
-      return YES;
+      hit = YES;
+      break;
     }
   }
-  return NO;
+
+  NSUInteger calls = atomic_fetch_add(&fbVisCacheTierBCalls, 1) + 1;
+  if (hit) {
+    atomic_fetch_add(&fbVisCacheTierBHits, 1);
+  }
+  if (0 == (calls % 50)) {
+    NSUInteger hits = atomic_load(&fbVisCacheTierBHits);
+    double hitRate = 100.0 * (double)hits / (double)calls;
+    [FBLogger logFmt:@"[VisCache] Tier-B stats: calls=%lu hits=%lu (%.1f%%) lastWalked=%lu lastResult=%@",
+     (unsigned long)calls,
+     (unsigned long)hits,
+     hitRate,
+     (unsigned long)descendantsWalked,
+     hit ? @"YES" : @"NO"];
+  }
+  return hit;
 }
 
 - (BOOL)fb_isVisible


### PR DESCRIPTION
## Summary

Pure-observability PR — adds logging to `fb_hasVisibleDescendants` so we can measure how often the descendant-cache shortcut actually fires on production / staging traffic. **No behaviour change**, just a log line.

Supersedes #15 (closed when the branch was renamed off internal shorthand).

## Context

`fb_isVisible` ([XCUIElement+FBIsVisible.m](https://github.com/qawolf/WebDriverAgent/blob/poc/log-visibility-cache-hits/WebDriverAgentLib/Categories/XCUIElement%2BFBIsVisible.m)) resolves visibility through three paths:

- Cached lookup on the snapshot's `additionalAttributes`.
- A descendant-cache shortcut (`fb_hasVisibleDescendants`) that returns YES if any of the element's descendants is already cached as visible — skipping the expensive AX call.
- Synchronous AX-framework IPC as the fallback.

The hypothesis is that the descendant shortcut almost never fires in the standard `/source` path because nothing pre-populates the cache before XML generation runs. This PR confirms or refutes that hypothesis with hard data.

## Changes

`WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m`:

- Adds `<stdatomic.h>` and `FBLogger.h` imports.
- Wraps `fb_hasVisibleDescendants` with process-wide `_Atomic NSUInteger` counters for calls and hits.
- Every 50 calls, emits one log line with `calls` / `hits` / hit rate / last-walk depth / last result.

Counters are process-wide, not per-request — they accumulate over the lifetime of the runner. Comparing hit rate before/after a workload is a simple subtract.

## What we expect to see

Baseline: hit rate **near 0%** — confirming the shortcut is dead code in the standard `/source` path because the cache is never pre-populated.

If the rate turns out to be meaningfully > 0%, that's a surprise and worth investigating before we invest in pre-warming variants.

## How to test

1. Build/install on a runner.
2. Tail Appium/WDA logs.
3. Issue a few `GET /source` calls against a representative app/screen.
4. Grep for `[VisCache]` and read the hit rate.

## Why this as its own PR

Separated from #14 (visibility-cache pre-warming PoC) so it can land independently and give us data on master before we commit to the larger change. Safe to merge — no behaviour change, just logging.

## Note on terminology

The code/comments shipped in this PR still carry some internal shorthand from the design discussion ("Tier B short-circuit", `[VisCache] Tier-B stats:` log prefix). That phrasing isn't meaningful outside the design conversation and will be cleaned up before this lands; please mentally substitute "descendant-cache shortcut" wherever you see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)